### PR TITLE
fixes to build with wolfBoot-RSA2048

### DIFF
--- a/wolfcrypt/src/asn_cert.c
+++ b/wolfcrypt/src/asn_cert.c
@@ -67,7 +67,6 @@ WOLFSSL_LOCAL int GetLength(const byte* input, word32* inOutIdx, int* len,
     return GetLength_ex(input, inOutIdx, len, maxIdx, 1);
 }
 
-
 /* give option to check length value found against index. 1 to check 0 to not */
 WOLFSSL_LOCAL int GetLength_ex(const byte* input, word32* inOutIdx, int* len,
                            word32 maxIdx, int check)
@@ -247,6 +246,27 @@ static int GetASNInt(const byte* input, word32* inOutIdx, int* len,
 
     return 0;
 }
+
+#if (!defined(WOLFSSL_KEY_GEN) && !defined(OPENSSL_EXTRA) && defined(RSA_LOW_MEM)) \
+    || defined(WOLFSSL_RSA_PUBLIC_ONLY)
+#if !defined(NO_RSA) && !defined(HAVE_USER_RSA)
+static int SkipInt(const byte* input, word32* inOutIdx, word32 maxIdx)
+{
+    word32 idx = *inOutIdx;
+    int    ret;
+    int    length;
+
+    ret = GetASNInt(input, &idx, &length, maxIdx);
+    if (ret != 0)
+        return ret;
+
+    *inOutIdx = idx + length;
+
+    return 0;
+}
+#endif
+#endif
+
 
 #if !defined(NO_DSA) && !defined(NO_SHA)
 static char sigSha1wDsaName[] = "SHAwDSA";

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -24,7 +24,6 @@
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
-#ifndef HAVE_DO178
 /*
  * SHA256 Build Options:
  * USE_SLOW_SHA256:            Reduces code size by not partially unrolling


### PR DESCRIPTION
Please consider for inclusion in your DO-178 trimming.

- 26f8a40b6124da04a36cea1c4b8962f6c6703f3e fixes an extra ifdef in sha256.c (it was causing a compile error when DO178 was off)

- bb2ecde9cb683352a50af81fedb7f027cae7c1a2 adds the function SkipInt to asn_cert.c. This is necessary, ~~i.e.~~ e.g. when compiling with `WOLFSSL_RSA_PUBLIC_ONLY`

Thanks!
/d