### PR TITLE
Fix for Valgrind error

### DIFF
--- a/tests/suites.c
+++ b/tests/suites.c
@@ -672,6 +672,7 @@ int SuiteTest(int argc, char** argv)
     func_args args;
     char argv0[3][80];
     char* myArgv[3];
+    WOLFSSL_METHOD* method = NULL;
 
     printf(" Begin Cipher Suite Tests\n");
 
@@ -685,8 +686,10 @@ int SuiteTest(int argc, char** argv)
 #ifdef WOLFSSL_STATIC_MEMORY
     byte memory[200000];
 #endif
-
-    cipherSuiteCtx = wolfSSL_CTX_new(wolfSSLv23_client_method());
+    method = wolfSSLv23_client_method();
+    if (method == NULL)
+        goto exit;
+    cipherSuiteCtx = wolfSSL_CTX_new(method);
     if (cipherSuiteCtx == NULL) {
         printf("can't get cipher suite ctx\n");
         args.return_code = EXIT_FAILURE;


### PR DESCRIPTION
Fix for errors found with Valgrind. 

$ valgrind --version
valgrind-3.10.0

$ gcc --version
gcc (Debian 4.9.2-10+deb8u2) 4.9.2
...
$ uname -r
3.16.0-10-amd64
